### PR TITLE
Logstash

### DIFF
--- a/logstash/config/logstash.yaml
+++ b/logstash/config/logstash.yaml
@@ -1,0 +1,3 @@
+http.host: "0.0.0.0"
+# 모니터링(X-Pack) 같은 건 안 씀
+pipeline.ecs_compatibility: disabled

--- a/logstash/config/pipeline.yaml
+++ b/logstash/config/pipeline.yaml
@@ -1,0 +1,3 @@
+- pipeline.id: teleport-audit
+  path.config: "/usr/share/logstash/pipeline/teleport-audit.conf"
+  queue.type: persisted

--- a/logstash/docker-compose.yaml
+++ b/logstash/docker-compose.yaml
@@ -1,0 +1,21 @@
+version: "3.8"
+
+services:
+  logstash:
+    image: opensearchproject/logstash-oss-with-opensearch-output-plugin:latest
+    container_name: logstash
+    command: logstash -f /usr/share/logstash/pipeline/teleport-audit.conf # pipeline 설정 파일을 지정함.
+    volumes:
+      - ./pipeline:/usr/share/logstash/pipeline
+      - ./config:/usr/share/logstash/config
+      - /Users/choijeongsik/Desktop/log-audit/data/logs:/teleport-logs # teleport 로그를 도커에 mount.
+    ports:
+      - "5001:5000"
+#    depends_on:
+#      - opensearch-node1  # 기존 OpenSearch 컨테이너 이름
+    networks:
+      - opensearch-net
+
+networks:
+  opensearch-net:
+    external: true

--- a/logstash/pipeline/teleport-audit.conf
+++ b/logstash/pipeline/teleport-audit.conf
@@ -1,0 +1,25 @@
+input {
+  file {
+    path => "/teleport-logs/*.log"
+    codec => json
+    start_position => "beginning"
+    sincedb_path => "/dev/null"  # 테스트용: 매번 처음부터 읽기
+  }
+}
+
+output {
+  # OpenSearch로 쓰기
+  opensearch {
+    hosts => ["https://opensearch-node1:9200"]
+    user  => "logstash"       # Dashboards에서 만든 수집 전용 계정
+    password => "Dhk147159*"      # ↑ 계정 비밀번호로 교체
+    index => "audit-events-%{+YYYY.MM.dd}"
+
+    # 개발/테스트 편의를 위해 인증서 검증만 잠시 끄기(자체서명 cert 사용시)
+    ssl => true
+    ssl_certificate_verification => false
+  }
+
+  # 디버깅용 콘솔 출력
+  stdout { codec => rubydebug }
+}


### PR DESCRIPTION
- teleport와 logstash를 연결.
- docker를 통해 logstash 구동.
- local의 log 파일을 logstash를 통해 openSearch로 넘김.
- openSearch로 넘길 때, index를 지정하여 "audit-events-%{+YYYY.MM.dd}" 형식으로 넘김.